### PR TITLE
Add caching service interfaces

### DIFF
--- a/Caching/ICachingService.cs
+++ b/Caching/ICachingService.cs
@@ -1,0 +1,9 @@
+﻿namespace Promact.Core.Caching
+{
+    public interface ICachingService
+    {
+        void Set<T>(string key, T value);
+        T Get<T>(string key);
+        void Remove(string key);
+    }
+}

--- a/Caching/ICachingUniqueKeyGenerationService.cs
+++ b/Caching/ICachingUniqueKeyGenerationService.cs
@@ -1,0 +1,7 @@
+﻿namespace Promact.Core.Caching
+{
+    public interface ICachingUniqueKeyGenerationService
+    {
+        string GenerateUniqueKey(string key);
+    }
+}

--- a/Promact.Core.csproj
+++ b/Promact.Core.csproj
@@ -9,6 +9,7 @@
     <PackageProjectUrl>https://github.com/Promact/Core</PackageProjectUrl>    
     <RepositoryUrl>https://github.com/Promact/Core</RepositoryUrl>
     <PackageReadmeFile>README.md</PackageReadmeFile>
+    <AssemblyVersion>1.0.0.1</AssemblyVersion>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Introduced two new interfaces in the Promact.Core.Caching namespace to enhance caching capabilities. The ICachingService interface defines methods for setting, getting, and removing cache values. The ICachingUniqueKeyGenerationService interface provides a method for generating unique cache keys based on provided keys.